### PR TITLE
Fix ListValues() "slice bounds out of range" panic on empty string input.

### DIFF
--- a/types/xsdtypes.go
+++ b/types/xsdtypes.go
@@ -971,6 +971,9 @@ type ToXsdtUnsignedShort interface {
 
 // XSD "list" types are always space-separated strings. All generated Go types based on any XSD's list types get a Values() method, which will always resort to this function.
 func ListValues(v string) (spl []string) {
+	if len(v) == 0 {
+		return
+	}
 	lastWs := true
 	wsr := func(r rune) bool {
 		return (r == ' ') || (r == '\r') || (r == '\n') || (r == '\t')


### PR DESCRIPTION
Fixes the following issue:

```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/metaleap/go-xsd/types.ListValues(0x340ce0, 0x0, 0x0, 0x0, 0x0, ...)
    /Users/Dmitri/Dmitri/^Work/^GitHub/Conception/GoLanding/src/github.com/metaleap/go-xsd/types/xsdtypes.go:984 +0x88
github.com/go3d/go-collada/imp-1%2e5.load_NodeDef(0xc200132480, 0xc2000b8900)
    /Users/Dmitri/Dmitri/^Work/^GitHub/Conception/GoLanding/src/github.com/go3d/go-collada/imp-1.5/imploads.go:1427 +0xd9
github.com/go3d/go-collada/imp-1%2e5.init_NodeDef(0xc200132480, 0xc2000b8900)
    /Users/Dmitri/Dmitri/^Work/^GitHub/Conception/GoLanding/src/github.com/go3d/go-collada/imp-1.5/impinits.go:857 +0xe7
...
```

It will still panic if given a non-empty string consisting of only whitespace.

I don't know the exact business requirements for this function, but I'm pretty sure it can be rewritten to make use of Go's standard library (e.g. http://golang.org/pkg/strings/ has funcs like Trim(), TrimLeft(), TrimLeftFunc(), Split(), etc.) to be much more concise, easier to understand and maintain, and less error-prone.

Perhaps the whole ListValues() func can be replaced with something along the lines of:

``` go
return strings.Split(strings.Trim(v, " \r\n\t"), " ")
```

Or slightly more verbose depending on the exact business requirements.
