### PR TITLE
Ensure import names are valid Go identifiers

### DIFF
--- a/elemmakepkg.go
+++ b/elemmakepkg.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"unicode"
 
 	"github.com/go-utils/ustr"
 
@@ -516,7 +517,7 @@ func (me *Import) makePkg(bag *PkgBag) {
 	me.hasElemAnnotation.makePkg(bag)
 	for k, v := range bag.Schema.XMLNamespaces {
 		if v == me.Namespace {
-			impName = k
+			impName = safeIdentifier(k)
 			break
 		}
 	}
@@ -834,6 +835,24 @@ func pluralize(s string) string {
 
 func sfmt(s string, a ...interface{}) string {
 	return fmt.Sprintf(s, a...)
+}
+
+// For any rune, return a rune that is a valid in an identifier
+func coerceToIdentifierRune(ch rune) rune {
+	if !unicode.IsLetter(ch) && !unicode.IsNumber(ch) {
+		return '_'
+	}
+	return ch
+}
+
+// Take any string and convert it to a valid identifier
+// Appends an underscore if the first rune is a number
+func safeIdentifier(s string) string {
+	s = strings.Map(coerceToIdentifierRune, s)
+	if unicode.IsNumber([]rune(s)[0]) {
+		s = fmt.Sprint("_", s)
+	}
+	return s
 }
 
 func subMakeElem(bag *PkgBag, td *declType, el *Element, done map[string]bool, parentMaxOccurs xsdt.Long, anns ...*Annotation) {

--- a/makepkg.go
+++ b/makepkg.go
@@ -274,6 +274,7 @@ func (me *PkgBag) resolveQnameRef(ref, pref string, noUsageRec *string) string {
 	}
 	if pos := strings.Index(ref, ":"); pos > 0 {
 		impName, ns = ref[:pos], me.Schema.XMLNamespaces[ref[:pos]]
+		impName = safeIdentifier(impName)
 		ref = ref[(pos + 1):]
 	}
 	if ns == xsdNamespaceUri {


### PR DESCRIPTION
Invalid Go identifiers were being generated, specifically with the
common case of hypenated XSD import names.

Example: https://nvd.nist.gov/schema/vulnerability_0.4.1.xsd